### PR TITLE
SHVE-1 - When git tags versions are not properly ordered, change log …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # sh-versioner
 
+## Tested with
+* sh-versioner v1.0.0
+* osx 10.14
+* make 3.81
+* git 2.3.2
+
 ## How it works
 The script's mechanics relies on git tags. It checks what are the differences between particular tags (newest and older one) and based on that generates changelog.
 

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 REPOSITORY=http://github.com/oskarszura/sh-changelog
-NEWER_TAG=$(git tag | tail -r | sed -n 1p)
-OLDER_TAG=$(git tag | tail -r | sed -n 2p)
+NEWER_TAG=$(git tag --sort version:refname | tail -r | sed -n 1p)
+OLDER_TAG=$(git tag --sort version:refname | tail -r | sed -n 2p)
 HEADER="# Changelog from $NEWER_TAG"
 DIR=./docs/changelogs
 


### PR DESCRIPTION
…script generates wrong version

**Business justification:** https://trello.com/c/Wv3BgWxW/7-shve-1-when-git-tags-versions-are-not-properly-ordered-change-log-script-generates-wrong-version

**Description:** When commiting more than one digit versions like `v.10.0`, the changelog script was confused which version was recent - as `git log` didn't sort by date by default. This PR improves the process about sorting by date so the changelog script can retrieve versions properly.